### PR TITLE
Add Apple stock plotting script

### DIFF
--- a/apple_stock_plot.py
+++ b/apple_stock_plot.py
@@ -1,0 +1,15 @@
+import yfinance as yf
+import matplotlib.pyplot as plt
+
+# Download historical data for Apple (AAPL)
+data = yf.download('AAPL', start='2020-01-01')
+
+# Plot the closing price over time
+plt.figure(figsize=(10, 5))
+plt.plot(data.index, data['Close'])
+plt.title('Apple Stock Price')
+plt.xlabel('Date')
+plt.ylabel('Closing Price (USD)')
+plt.grid(True)
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
## Summary
- add a small Python script that downloads Apple stock data with yfinance and plots the closing price

## Testing
- `python apple_stock_plot.py` *(fails: ModuleNotFoundError - yfinance not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2a3fa908324b10caf55b810059c